### PR TITLE
Revert "Adding status.Flags check to validation"

### DIFF
--- a/Gen6_BL_Demo/Borax_BL.c
+++ b/Gen6_BL_Demo/Borax_BL.c
@@ -425,7 +425,7 @@ bool BL_program(const uint8_t * buf, uint32_t numBytes, uint32_t address)
 	// Validate.
 	BL_cmd_validate(1);
 	delay(10);
-	if( !BL_get_status( &status ) || status.LastError != NO_ERROR || ( status.Flags & 0x10 ) == 0 )
+	if( !BL_get_status( &status ) || status.LastError != NO_ERROR /* || ( status.Flags & 0x10 ) == 0 */ )
 	{
 		BL_cmd_format_image( 0, 1, EntryPoint, TargetHIDDescAddr, TargetI2CAddress, BL_REPORT_ID );
 		return false;


### PR DESCRIPTION
This reverts commit 3a202bc25980e7f60a07d97ce23d3613ff790e6d.

It seems this line can be dangerous. Further testing is required.